### PR TITLE
Set correct `requests` library version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ PY_34 = sys.version_info >= (3,4)
 
 here = path.abspath(path.dirname(__file__))
 
-install_requires = ['requests']
+install_requires = ['requests>=2.4.0']
 cmdclass = {}
 
 if PY_34:


### PR DESCRIPTION
`requests` v. < 2.4.0 causes such trace:

    >>> import telepot
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File "/usr/local/lib/python3.4/dist-packages/telepot/__init__.py", line 17, in <module>
        requests.packages.urllib3.disable_warnings()
    AttributeError: 'module' object has no attribute 'disable_warnings'
