### PR TITLE
TelegramError, added parameters

### DIFF
--- a/telepot/__init__.py
+++ b/telepot/__init__.py
@@ -166,7 +166,12 @@ class Bot(_BotBase):
         if data['ok']:
             return data['result']
         else:
-            raise TelegramError(data['description'], data['error_code'], data['parameters'])
+            if 'parameters' in data:
+                parameters = data['parameters']
+            else:
+                parameters = None
+
+            raise TelegramError(data['description'], data['error_code'], parameters)
 
     def getMe(self):
         r = requests.post(self._methodurl('getMe'), timeout=self._http_timeout)

--- a/telepot/__init__.py
+++ b/telepot/__init__.py
@@ -166,7 +166,7 @@ class Bot(_BotBase):
         if data['ok']:
             return data['result']
         else:
-            raise TelegramError(data['description'], data['error_code'])
+            raise TelegramError(data['description'], data['error_code'], data['parameters'])
 
     def getMe(self):
         r = requests.post(self._methodurl('getMe'), timeout=self._http_timeout)

--- a/telepot/__init__.py
+++ b/telepot/__init__.py
@@ -166,7 +166,7 @@ class Bot(_BotBase):
         if data['ok']:
             return data['result']
         else:
-            raise TelegramError(data['description'], data['error_code'], data['parameters'])
+            raise TelegramError(data['description'], data['error_code'], response.text, data['parameters'])
 
     def getMe(self):
         r = requests.post(self._methodurl('getMe'), timeout=self._http_timeout)

--- a/telepot/__init__.py
+++ b/telepot/__init__.py
@@ -166,7 +166,7 @@ class Bot(_BotBase):
         if data['ok']:
             return data['result']
         else:
-            raise TelegramError(data['description'], data['error_code'], response.text, data['parameters'])
+            raise TelegramError(data['description'], data['error_code'], data['parameters'])
 
     def getMe(self):
         r = requests.post(self._methodurl('getMe'), timeout=self._http_timeout)

--- a/telepot/async/__init__.py
+++ b/telepot/async/__init__.py
@@ -45,7 +45,7 @@ class Bot(telepot._BotBase):
         if data['ok']:
             return data['result']
         else:
-            raise TelegramError(data['description'], data['error_code'])
+            raise TelegramError(data['description'], data['error_code'], data['parameters'])
 
     @asyncio.coroutine
     def getMe(self):

--- a/telepot/async/__init__.py
+++ b/telepot/async/__init__.py
@@ -45,7 +45,7 @@ class Bot(telepot._BotBase):
         if data['ok']:
             return data['result']
         else:
-            raise TelegramError(data['description'], data['error_code'], response.text, data['parameters'])
+            raise TelegramError(data['description'], data['error_code'], data['parameters'])
 
     @asyncio.coroutine
     def getMe(self):

--- a/telepot/async/__init__.py
+++ b/telepot/async/__init__.py
@@ -45,7 +45,12 @@ class Bot(telepot._BotBase):
         if data['ok']:
             return data['result']
         else:
-            raise TelegramError(data['description'], data['error_code'], data['parameters'])
+            if 'parameters' in data:
+                parameters = data['parameters']
+            else:
+                parameters = None
+
+            raise TelegramError(data['description'], data['error_code'], parameters)
 
     @asyncio.coroutine
     def getMe(self):

--- a/telepot/async/__init__.py
+++ b/telepot/async/__init__.py
@@ -45,7 +45,7 @@ class Bot(telepot._BotBase):
         if data['ok']:
             return data['result']
         else:
-            raise TelegramError(data['description'], data['error_code'], data['parameters'])
+            raise TelegramError(data['description'], data['error_code'], response.text, data['parameters'])
 
     @asyncio.coroutine
     def getMe(self):

--- a/telepot/exception.py
+++ b/telepot/exception.py
@@ -25,8 +25,8 @@ class BadHTTPResponse(TelepotException):
 
 
 class TelegramError(TelepotException):
-    def __init__(self, description, error_code, parameters=None):
-        super(TelegramError, self).__init__(description, error_code, parameters)
+    def __init__(self, description, error_code, raw_response=None, parameters=None):
+        super(TelegramError, self).__init__(description, error_code, raw_response, parameters)
 
     @property
     def description(self):
@@ -37,8 +37,12 @@ class TelegramError(TelepotException):
         return self.args[1]
 
     @property
-    def parameters(self):
+    def raw_response(self):
         return self.args[2]
+
+    @property
+    def parameters(self):
+        return self.args[3]
 
 
 class WaitTooLong(TelepotException):

--- a/telepot/exception.py
+++ b/telepot/exception.py
@@ -25,7 +25,7 @@ class BadHTTPResponse(TelepotException):
 
 
 class TelegramError(TelepotException):
-    def __init__(self, description, error_code, parameters):
+    def __init__(self, description, error_code, parameters=None):
         super(TelegramError, self).__init__(description, error_code, parameters)
 
     @property

--- a/telepot/exception.py
+++ b/telepot/exception.py
@@ -25,8 +25,8 @@ class BadHTTPResponse(TelepotException):
 
 
 class TelegramError(TelepotException):
-    def __init__(self, description, error_code, raw_response=None, parameters=None):
-        super(TelegramError, self).__init__(description, error_code, raw_response, parameters)
+    def __init__(self, description, error_code, parameters=None):
+        super(TelegramError, self).__init__(description, error_code, parameters)
 
     @property
     def description(self):
@@ -37,12 +37,8 @@ class TelegramError(TelepotException):
         return self.args[1]
 
     @property
-    def raw_response(self):
-        return self.args[2]
-
-    @property
     def parameters(self):
-        return self.args[3]
+        return self.args[2]
 
 
 class WaitTooLong(TelepotException):

--- a/telepot/exception.py
+++ b/telepot/exception.py
@@ -1,6 +1,7 @@
 class TelepotException(Exception):
     pass
 
+
 class BadFlavor(TelepotException):
     def __init__(self, offender):
         super(BadFlavor, self).__init__(offender)
@@ -8,6 +9,7 @@ class BadFlavor(TelepotException):
     @property
     def offender(self):
         return self.args[0]
+
 
 class BadHTTPResponse(TelepotException):
     def __init__(self, status, text):
@@ -21,9 +23,10 @@ class BadHTTPResponse(TelepotException):
     def text(self):
         return self.args[1]
 
+
 class TelegramError(TelepotException):
-    def __init__(self, description, error_code):
-        super(TelegramError, self).__init__(description, error_code)
+    def __init__(self, description, error_code, parameters):
+        super(TelegramError, self).__init__(description, error_code, parameters)
 
     @property
     def description(self):
@@ -33,8 +36,14 @@ class TelegramError(TelepotException):
     def error_code(self):
         return self.args[1]
 
+    @property
+    def parameters(self):
+        return self.args[2]
+
+
 class WaitTooLong(TelepotException):
     pass
+
 
 class StopListening(TelepotException):
     def __init__(self, code=None, reason=None):


### PR DESCRIPTION
This will add telegrams parameters response in TelegramError.

Example: 
`TelegramError('[Error]: Bad Request: group chat is migrated to supergroup chat', 400)`
changes to:
`TelegramError('[Error]: Bad Request: group chat is migrated to supergroup chat', 400, {'migrate_to_chat_id': xxxxxxxxxx})`