### PR TITLE
Fix aiohttp 'Unclosed client session' warning.

### DIFF
--- a/telepot/aio/api.py
+++ b/telepot/aio/api.py
@@ -1,6 +1,7 @@
 import asyncio
 import aiohttp
 import async_timeout
+import atexit
 import re
 import json
 from .. import exception
@@ -13,6 +14,8 @@ _pools = {
                    connector=aiohttp.TCPConnector(limit=10),
                    loop=_loop)
 }
+
+atexit.register(_pools['default'].close)
 
 _timeout = 30
 


### PR DESCRIPTION
The aiohttp module creates a warning when it finds an unclosed client
session. There is one session that is never closed. The solution is to
register atexit call to close it properly.