### PR TITLE
provide access to the started longpolling request

### DIFF
--- a/telepot/aio/loop.py
+++ b/telepot/aio/loop.py
@@ -75,9 +75,11 @@ class MessageLoop(object):
                                      lambda update:
                                          self._handle(_extract_message(update)[1]))
 
-        self._bot.loop.create_task(updatesloop.run_forever(*args, **kwargs))
+        task = self._bot.loop.create_task(
+            updatesloop.run_forever(*args, **kwargs))
 
         self._bot.scheduler.on_event(self._handle)
+        return task
 
 
 class Webhook(object):


### PR DESCRIPTION
This PR resolves #259 

``telepot.aio.loop.MessageLoop.run_forever`` now returns a ``asyncio.Task`` instance that can be used to cancel the loop.