### PR TITLE
cover a response with a non-json content type

### DIFF
--- a/telepot/aio/api.py
+++ b/telepot/aio/api.py
@@ -97,7 +97,7 @@ async def _parse(response):
         data = await response.json()
         if data is None:
             raise ValueError()
-    except (ValueError, json.JSONDecodeError):
+    except (ValueError, json.JSONDecodeError, aiohttp.ClientResponseError):
         text = await response.text()
         raise exception.BadHTTPResponse(response.status, text, response)
 


### PR DESCRIPTION
The coroutine `aiohttp.ClientResponse.json()` raises an `aiohttp.ClientResponseError` in case of a non-json content type specified in the `aiohttp.ClientResponse.headers`.
This behaviour got introduced in https://github.com/aio-libs/aiohttp/commit/8974844fb1618b2fe6882b0e2dcf2dee60bc9eae, which is part of `aiohttp>=2.0.0`.

The content type `text/html` is common during late-startup of `nginx`, which powers the Telegram-Servers.
The _invalid_ content type is a result of a received `502 - Bad Gateway`-error.