### PR TITLE
[aio.api] reraise a connection-TimeoutError as TelegramError

### DIFF
--- a/telepot/aio/api.py
+++ b/telepot/aio/api.py
@@ -133,10 +133,14 @@ async def request(req, **user_kw):
         if timeout is None:
             async with fn(*args, **kwargs) as r:
                 return await _parse(r)
-        else:
+
+        try:
             with async_timeout.timeout(timeout):
                 async with fn(*args, **kwargs) as r:
                     return await _parse(r)
+        except asyncio.TimeoutError:
+            raise exception.TelegramError('Response timeout', 504, {}) from None
+
     finally:
         if cleanup:
             cleanup()  # e.g. closing one-time session


### PR DESCRIPTION
`telepot` sets a timeout for async requests, but does not mark the the raised exception as intended.

As Telegram uses ngix servers as edge server for their internal infrastructure, a 504 (re Gateway Timeout) status code seems to fit here. In addition we drop the previous `asyncio.TimeoutError` from the stack.


Example stack:
```python
Traceback (most recent call last):
  File "/opt/venv/lib/python3.5/site-packages/telepot/aio/api.py", line 127, in request
    async with fn(*args, **kwargs) as r:
  File "/opt/venv/lib/python3.5/site-packages/aiohttp/client.py", line 603, in __aenter__
    self._resp = yield from self._coro
  File "/opt/venv/lib/python3.5/site-packages/aiohttp/client.py", line 241, in _request
    yield from resp.start(conn, read_until_eof)
  File "/opt/venv/lib/python3.5/site-packages/aiohttp/client_reqrep.py", line 559, in start
    (message, payload) = yield from self._protocol.read()
  File "/opt/venv/lib/python3.5/site-packages/aiohttp/streams.py", line 509, in read
    yield from self._waiter
  File "/usr/local/lib/python3.5/asyncio/futures.py", line 381, in __iter__
    yield self  # This tells Task to wait for completion.
  File "/usr/local/lib/python3.5/asyncio/tasks.py", line 310, in _wakeup
    future.result()
  File "/usr/local/lib/python3.5/asyncio/futures.py", line 286, in result
    raise CancelledError
concurrent.futures._base.CancelledError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/hangoutsbot/hangupsbot/plugins/telesync/core.py", line 725, in _message_loop
    updates = await self.getUpdates(offset=offset, timeout=120)
  File "/opt/venv/lib/python3.5/site-packages/telepot/aio/__init__.py", line 517, in getUpdates
    return await self._api_request('getUpdates', _rectify(p))
  File "/opt/venv/lib/python3.5/site-packages/telepot/aio/__init__.py", line 75, in _api_request
    return await api.request((self._token, method, params, files), **kwargs)
  File "/opt/venv/lib/python3.5/site-packages/telepot/aio/api.py", line 128, in request
    return await _parse(r)
  File "/opt/venv/lib/python3.5/site-packages/async_timeout/__init__.py", line 35, in __exit__
    self._do_exit(exc_type)
  File "/opt/venv/lib/python3.5/site-packages/async_timeout/__init__.py", line 80, in _do_exit
    raise asyncio.TimeoutError
concurrent.futures._base.TimeoutError
```