### PR TITLE
[aio.api] raise a ConnectionError as TelegramError

### DIFF
--- a/telepot/aio/api.py
+++ b/telepot/aio/api.py
@@ -137,6 +137,9 @@ async def request(req, **user_kw):
             with async_timeout.timeout(timeout):
                 async with fn(*args, **kwargs) as r:
                     return await _parse(r)
+
+    except aiohttp.ClientConnectionError:
+        raise exception.TelegramError('Connection Error', 400, {})
     finally:
         if cleanup:
             cleanup()  # e.g. closing one-time session


### PR DESCRIPTION
This PR adds coverage of failed connection initialisation to `telepot.aio`.

Example Trace:
```python
Traceback (most recent call last):
  File "/opt/venv/lib/python3.5/site-packages/aiohttp/connector.py", line 796, in _create_direct_connection
    local_addr=self._local_addr)
  File "/usr/local/lib/python3.5/asyncio/base_events.py", line 776, in create_connection
    raise exceptions[0]
  File "/usr/local/lib/python3.5/asyncio/base_events.py", line 763, in create_connection
    yield from self.sock_connect(sock, address)
  File "/usr/local/lib/python3.5/asyncio/selector_events.py", line 451, in sock_connect
    return (yield from fut)
  File "/usr/local/lib/python3.5/asyncio/futures.py", line 381, in __iter__
    yield self  # This tells Task to wait for completion.
  File "/usr/local/lib/python3.5/asyncio/tasks.py", line 310, in _wakeup
    future.result()
  File "/usr/local/lib/python3.5/asyncio/futures.py", line 294, in result
    raise self._exception
  File "/usr/local/lib/python3.5/asyncio/selector_events.py", line 481, in _sock_connect_cb
    raise OSError(err, 'Connect call failed %s' % (address,))
TimeoutError: [Errno 110] Connect call failed ('149.154.167.197', 443)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "telegram.py", line 102, in message_loop
    updates = await self.getUpdates(offset=offset, timeout=120)
  File "/opt/venv/lib/python3.5/site-packages/telepot/aio/__init__.py", line 550, in getUpdates
    return await self._api_request('getUpdates', _rectify(p))
  File "/opt/venv/lib/python3.5/site-packages/telepot/aio/__init__.py", line 75, in _api_request
    return await api.request((self._token, method, params, files), **kwargs)
  File "/opt/venv/lib/python3.5/site-packages/telepot/aio/api.py", line 138, in request
    async with fn(*args, **kwargs) as r:
  File "/opt/venv/lib/python3.5/site-packages/aiohttp/client.py", line 692, in __aenter__
    self._resp = yield from self._coro
  File "/opt/venv/lib/python3.5/site-packages/aiohttp/client.py", line 269, in _request
    conn = yield from self._connector.connect(req)
  File "/opt/venv/lib/python3.5/site-packages/aiohttp/connector.py", line 392, in connect
    proto = yield from self._create_connection(req)
  File "/opt/venv/lib/python3.5/site-packages/aiohttp/connector.py", line 737, in _create_connection
    _, proto = yield from self._create_direct_connection(req)
  File "/opt/venv/lib/python3.5/site-packages/aiohttp/connector.py", line 823, in _create_direct_connection
    raise ClientConnectorError(req.connection_key, exc) from exc
aiohttp.client_exceptions.ClientConnectorError: Cannot connect to host api.telegram.org:443 ssl:True [Connect call failed ('149.154.167.197', 443)]
```