### PR TITLE
[api] hotfix for proxy-auth

### DIFF
--- a/telepot/api.py
+++ b/telepot/api.py
@@ -23,7 +23,7 @@ _onetime_pool_spec = (urllib3.PoolManager, _onetime_pool_params)
 def set_proxy(url, basic_auth=None):
     """
     Access Bot API through a proxy.
-    
+
     :param url: proxy URL
     :param basic_auth: 2-tuple ``('username', 'password')``
     """
@@ -33,8 +33,8 @@ def set_proxy(url, basic_auth=None):
         _onetime_pool_spec = (urllib3.PoolManager, _onetime_pool_params)
     elif basic_auth:
         h = urllib3.make_headers(proxy_basic_auth=':'.join(basic_auth))
-        _pools['default'] = urllib3.ProxyManager(url, headers=h, **_default_pool_params)
-        _onetime_pool_spec = (urllib3.ProxyManager, dict(proxy_url=url, headers=h, **_onetime_pool_params))
+        _pools['default'] = urllib3.ProxyManager(url, proxy_headers=h, **_default_pool_params)
+        _onetime_pool_spec = (urllib3.ProxyManager, dict(proxy_url=url, proxy_headers=h, **_onetime_pool_params))
     else:
         _pools['default'] = urllib3.ProxyManager(url, **_default_pool_params)
         _onetime_pool_spec = (urllib3.ProxyManager, dict(proxy_url=url, **_onetime_pool_params))


### PR DESCRIPTION
This PR resolves #327.

Authentication for the proxy may be supplied in `proxy_headers` when using `urllib3.ProxyManager`. 
From the [documentation of `urllib3.ProxyManager`](https://urllib3.readthedocs.io/en/latest/reference/index.html#urllib3.poolmanager.ProxyManager):
> Parameter | Description
> -- | --
> proxy_url | The URL of the proxy to be used.
> proxy_headers | A dictionary contaning headers that will be sent to the proxy. In case of HTTP they are being sent with each request, while in the HTTPS/CONNECT case they are sent only once. Could be used for proxy authentication.
