### PR TITLE
loop propagation for the underlying session

### DIFF
--- a/telepot/aio/__init__.py
+++ b/telepot/aio/__init__.py
@@ -113,7 +113,7 @@ class Bot(_BotBase):
             return self._timeout
 
     def _transform(self, req, **user_kw):
-        timeout = api._compose_timeout(req)
+        timeout = self._compose_timeout(req)
         data = api._compose_data(req)
         url = _methodurl(req, **user_kw)
 


### PR DESCRIPTION
Here is my fix for the #359
What have been done here:
- one `loop` object for Bot class and for underlying sessions. 
- removed `_pool`. I don't know what is the idea behind, so I reimplemented idea as `self.session`. I know that I probably lack some understanding why it has been done this way before. 
- I left some functions inside `telepot.aio.api` module, but I don't think it is worth to left it since most functions logically are part of the `Bot` class. 

I didn't make any additional tests since I'm working on a prototype of my project. It is a very early stage and I try to make pieces together. 