### PR TITLE
[aio.api] fix session cleanup

### DIFF
--- a/telepot/aio/__init__.py
+++ b/telepot/aio/__init__.py
@@ -59,6 +59,10 @@ class Bot(_BotBase):
                                               'inline_query': helper._create_invoker(self, 'on_inline_query'),
                                               'chosen_inline_result': helper._create_invoker(self, 'on_chosen_inline_result')})
 
+    @staticmethod
+    async def close():
+        await api.close_pools()
+
     @property
     def loop(self):
         return self._loop

--- a/telepot/aio/api.py
+++ b/telepot/aio/api.py
@@ -35,12 +35,13 @@ def _proxy_kwargs():
     else:
         raise RuntimeError("_proxy has invalid length")
 
-def _close_pools():
-    global _pools
-    for s in _pools.values():
-        s.close()
 
-atexit.register(_close_pools)
+async def close_pools():
+    """Close the global connection pools"""
+    global _pools
+    for session in _pools.values():
+        await session.close()
+
 
 def _create_onetime_pool():
     return aiohttp.ClientSession(
@@ -153,7 +154,7 @@ async def request(req, **user_kw):
 
     finally:
         if cleanup:
-            cleanup()  # e.g. closing one-time session
+            await cleanup()  # e.g. closing one-time session
 
 def download(req):
     session = _create_onetime_pool()


### PR DESCRIPTION
`aiohttp.ClientSession.close` it is a coroutine in `aiohttp>=3.0` and must be awaited.

The commit which introduced this change can be found here: https://github.com/aio-libs/aiohttp/commit/439c732f5bf29a83779dce6da4a55e7efd433cf8#diff-7dd84b5ef8d5eea2de1dfc5329411dfcR664

```
2018-03-20 21:40:12,581 WARNING py.warnings: /.../venv/lib/python3.6/site-packages/telepot/aio/api.py:156: RuntimeWarning: coroutine 'ClientSession.close' was never awaited
  cleanup()  # e.g. closing one-time session

2018-03-20 21:40:12,582 ERROR asyncio: Unclosed client session
client_session: <aiohttp.client.ClientSession object at 0x7f22ea175630>
```

This PR closes #378.