### PR TITLE
Ignore `asyncio.CancelledError` in `OrderedWebhook.run_forever`

### DIFF
--- a/telepot/aio/loop.py
+++ b/telepot/aio/loop.py
@@ -166,6 +166,9 @@ class OrderedWebhook(object):
                 else:
                     pass  # discard
 
+            except asyncio.CancelledError:
+                pass
+
             except asyncio.TimeoutError:
                 # debug message
                 # print('Timeout')


### PR DESCRIPTION
For a cleaner exit when tasks are cancelled